### PR TITLE
Rename from the default package name of react-native libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 #### Android
 
 1. Open up `android/app/src/main/java/[...]/MainApplication.java`
-  - Add `import com.reactlibrary.RNReactNativeHapticFeedbackPackage;` to the imports at the top of the file
+  - Add `import com.mkuczera.RNReactNativeHapticFeedbackPackage;` to the imports at the top of the file
   - Add `new RNReactNativeHapticFeedbackPackage()` to the list returned by the `getPackages()` method
 2. Append the following lines to `android/settings.gradle`:
   	```

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.reactlibrary">
+          package="com.mkuczera">
     <uses-permission android:name="android.permission.VIBRATE"></uses-permission>
 </manifest>
-  
+

--- a/android/src/main/java/com/mkuczera/RNReactNativeHapticFeedbackModule.java
+++ b/android/src/main/java/com/mkuczera/RNReactNativeHapticFeedbackModule.java
@@ -1,5 +1,5 @@
 
-package com.reactlibrary;
+package com.mkuczera;
 
 import android.os.Vibrator;
 import android.content.Context;

--- a/android/src/main/java/com/mkuczera/RNReactNativeHapticFeedbackPackage.java
+++ b/android/src/main/java/com/mkuczera/RNReactNativeHapticFeedbackPackage.java
@@ -1,5 +1,5 @@
 
-package com.reactlibrary;
+package com.mkuczera;
 
 import java.util.Arrays;
 import java.util.Collections;


### PR DESCRIPTION
Using the `com.reactlibrary` package will cause conflicts if the user of this library uses another that's doing the same.

Can cause errors like

```
Error:Execution failed for task ':app:processDebugResources'.
:More than one library with package name 'com.reactlibrary'
```

Or

```
Error:Execution failed for task ':app:transformDexArchiveWithDexMergerForReleaseD8'
Program type already present: com.reactlibrary.BuildConfig
```

The convention seems to be using the library owners name as part of the package. 

**Note** This will be a breaking change for those that already have this installed. They'll need to manually update the reference in their MainApplication.java file.

```diff
 import android.support.multidex.MultiDexApplication;
 import com.facebook.react.ReactApplication;
-import com.reactlibrary.RNReactNativeHapticFeedbackPackage;
+import com.mkuczera.RNReactNativeHapticFeedbackPackage;
 import au.com.up.contactpicker.RNContactPickerPackage;
 import io.invertase.firebase.RNFirebasePackage;
 import io.invertase.firebase.messaging.RNFirebaseMessagingPackage;
```