### PR TITLE
React doesn't need to be in the podspec (depricated)

### DIFF
--- a/RNReactNativeHapticFeedback.podspec
+++ b/RNReactNativeHapticFeedback.podspec
@@ -16,11 +16,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/author/RNReactNativeHapticFeedback.git", :tag => "master" }
   s.source_files  = "ios/*.{h,m}"
   s.requires_arc = true
-
-
-  s.dependency "React"
-  #s.dependency "others"
-
 end
 
   


### PR DESCRIPTION
Creates a duplicate react in the project