### PR TITLE
Enable react-native-haptic-feedback to be included in Podfile 

### DIFF
--- a/react-native-haptic-feedback.podspec
+++ b/react-native-haptic-feedback.podspec
@@ -2,11 +2,11 @@ require 'json'
 version = JSON.parse(File.read('package.json'))["version"]
 
 Pod::Spec.new do |s|
-  s.name         = "RNReactNativeHapticFeedback"
+  s.name         = "react-native-haptic-feedback"
   s.version      = version
-  s.summary      = "RNReactNativeHapticFeedback"
+  s.summary      = "react-native-haptic-feedback"
   s.description  = <<-DESC
-                  RNReactNativeHapticFeedback
+                  react-native-haptic-feedback
                    DESC
   s.homepage     = "https://github.com/mkuczera/react-native-haptic-feedback"
   s.license      = "MIT"
@@ -16,6 +16,8 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/author/RNReactNativeHapticFeedback.git", :tag => "master" }
   s.source_files  = "ios/*.{h,m}"
   s.requires_arc = true
+
+  s.dependency 'React'
 end
 
   


### PR DESCRIPTION
Our project includes react native modules via `pod 'react-native-haptic-feedback', :path => 'node_modules/react-native-haptic-feedback’`

Because of the mismatch in names between the project and the .podspec, this was not possible

I have renamed the .podspec file and further made explicit the dependency on React