### PR TITLE
Make it work for iPhone 6S and iPhone 6S Plus

### DIFF
--- a/ios/RNReactNativeHapticFeedback.m
+++ b/ios/RNReactNativeHapticFeedback.m
@@ -41,6 +41,17 @@ RCT_EXPORT_METHOD(trigger:(NSString *)type enableVibrateFallback:(BOOL)enableVib
             [self generateSelectionFeedback];
         }
         
+    } else if ([self supportsHapticFor6SAnd6SPlus]) {
+        
+        // generates alternative haptic feedback
+        if ([type isEqual: @"selection"]) {
+            AudioServicesPlaySystemSound((SystemSoundID) 1519);
+        } else if ([type isEqual: @"impactMedium"]) {
+            AudioServicesPlaySystemSound((SystemSoundID) 1520);
+        } else if ([type isEqual:@"notificationWarning"]) {
+            AudioServicesPlaySystemSound((SystemSoundID) 1521);
+        }
+        
     } else if (enableVibrateFallback) {
         AudioServicesPlaySystemSound(kSystemSoundID_Vibrate);
     }
@@ -49,8 +60,13 @@ RCT_EXPORT_METHOD(trigger:(NSString *)type enableVibrateFallback:(BOOL)enableVib
 
 -(Boolean)supportsHaptic {
     return [[UIDevice currentDevice] systemVersion].floatValue >= 10.0
-        && ![[DeviceUtils platform] isEqualToString:@"iPhone8,4"] // iPhone SE
-        && [DeviceUtils deviceVersion:@"iPhone"] > 7;
+        && [DeviceUtils deviceVersion:@"iPhone"] > 8;
+}
+
+-(Boolean)supportsHapticFor6SAnd6SPlus {
+    return [[UIDevice currentDevice] systemVersion].floatValue >= 10.0
+        && ([[DeviceUtils platform] isEqualToString:@"iPhone8,1"]  // iPhone 6S
+        || [[DeviceUtils platform] isEqualToString:@"iPhone8,2"]); // iPhone 6S Plus
 }
 
 -(void)generateSelectionFeedback{


### PR DESCRIPTION
Hey @mkuczera! Thank you for the library!

While testing it, I have encountered that it didn't work for iPhone 6S and 6S Plus, due to weak taptic engine that doesn't support all possible variants that work for >= iPhone 7. So I have added haptic feedback for some of the variants such as `selection`, `impactMedium` and `notificationWarning`.

This article have lead me to this -> https://medium.com/@sdrzn/make-your-ios-app-feel-better-a-comprehensive-guide-over-taptic-engine-and-haptic-feedback-724dec425f10