### PR TITLE
check haptic system settings before triggering

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,25 @@
 ```javascript
 import ReactNativeHapticFeedback from 'react-native-haptic-feedback';
 
-ReactNativeHapticFeedback.trigger('impactLight', true);
+const options = {
+  enableVibrateFallback: true,
+  ignoreAndroidSystemSettings: false
+}
+
+ReactNativeHapticFeedback.trigger('impactLight', options);
 ```
 
 ### Available methods
+
+#### trigger(method, options)
+
+Argument | Description
+------ | ------
+`method` | Possible values are "selection", "impactLight", "impactMedium", "impactHeavy", "notificationSuccess", "notificationWarning", "notificationError" (default: "selection")
+`options.enableVibrateFallback` | iOS only. if haptic feedback is not available (iOS < 10 OR Device < iPhone6s), vibrate with default method (heavy 1s)
+`options.ignoreAndroidSystemSettings` | Android only. if Haptic is disabled in the Android system settings this will allow ignoring the setting and trigger haptic feeback.
+
+### Available methods version 1.6.0 and prior
 
 #### trigger(method, enableVibrateFallback)
 

--- a/android/src/main/java/com/mkuczera/RNReactNativeHapticFeedbackModule.java
+++ b/android/src/main/java/com/mkuczera/RNReactNativeHapticFeedbackModule.java
@@ -29,7 +29,7 @@ public class RNReactNativeHapticFeedbackModule extends ReactContextBaseJavaModul
   @ReactMethod
   public void trigger(String type, ReadableMap options) {
     // Check system settings, if disabled and we're not explicitly ignoring then return immediatly
-    boolean ignoreAndroidSystemSettings = options.getBoolean('ignoreAndroidSystemSettings');
+    boolean ignoreAndroidSystemSettings = options.getBoolean("ignoreAndroidSystemSettings");
     int hapticEnabledAndroidSystemSettings = Settings.System.getInt(this.reactContext.getContentResolver(), Settings.System.HAPTIC_FEEDBACK_ENABLED, 0);
     if (ignoreAndroidSystemSettings == false && hapticEnabledAndroidSystemSettings == 0) return;
 

--- a/android/src/main/java/com/mkuczera/RNReactNativeHapticFeedbackModule.java
+++ b/android/src/main/java/com/mkuczera/RNReactNativeHapticFeedbackModule.java
@@ -3,6 +3,7 @@ package com.mkuczera;
 
 import android.os.Vibrator;
 import android.content.Context;
+import android.provider.Settings;
 
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -26,6 +27,9 @@ public class RNReactNativeHapticFeedbackModule extends ReactContextBaseJavaModul
 
   @ReactMethod
   public void trigger(String type) {
+    // Check system settings, if disabled return immediately
+    if (Settings.System.getInt(this.reactContext.getContentResolver(), Settings.System.HAPTIC_FEEDBACK_ENABLED, 0) == 0) return;
+
     Vibrator v = (Vibrator) reactContext.getSystemService(Context.VIBRATOR_SERVICE);
     if (v == null) return;
     long durations[] = {0, 20};

--- a/android/src/main/java/com/mkuczera/RNReactNativeHapticFeedbackModule.java
+++ b/android/src/main/java/com/mkuczera/RNReactNativeHapticFeedbackModule.java
@@ -10,6 +10,7 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.ReadableMap;
 
 public class RNReactNativeHapticFeedbackModule extends ReactContextBaseJavaModule {
 
@@ -26,9 +27,11 @@ public class RNReactNativeHapticFeedbackModule extends ReactContextBaseJavaModul
   }
 
   @ReactMethod
-  public void trigger(String type) {
-    // Check system settings, if disabled return immediately
-    if (Settings.System.getInt(this.reactContext.getContentResolver(), Settings.System.HAPTIC_FEEDBACK_ENABLED, 0) == 0) return;
+  public void trigger(String type, ReadableMap options) {
+    // Check system settings, if disabled and we're not explicitly ignoring then return immediatly
+    boolean ignoreAndroidSystemSettings = options.getBoolean('ignoreAndroidSystemSettings');
+    int hapticEnabledAndroidSystemSettings = Settings.System.getInt(this.reactContext.getContentResolver(), Settings.System.HAPTIC_FEEDBACK_ENABLED, 0);
+    if (ignoreAndroidSystemSettings == false && hapticEnabledAndroidSystemSettings == 0) return;
 
     Vibrator v = (Vibrator) reactContext.getSystemService(Context.VIBRATOR_SERVICE);
     if (v == null) return;

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,7 +8,10 @@ declare const ReactNativeHapticFeedback: {
       | "notificationSuccess"
       | "notificationWarning"
       | "notificationError",
-    enableVibrateFallback?: boolean
+    options?: {
+      enableVibrateFallback?: boolean,
+      ignoreAndroidSystemSettings?: boolean
+    }
   ): void;
 };
 

--- a/index.js
+++ b/index.js
@@ -2,15 +2,20 @@ import { NativeModules, Platform } from 'react-native';
 
 class RNReactNativeHapticFeedback {
     static trigger = (type = 'selection', options = {}) => {
+        const mergedOptions = {
+            ignoreAndroidSystemSettings: false,
+            ...options
+        }
+
         try {
             if (typeof options === 'boolean') {
                 if (Platform === 'ios') {
                     NativeModules.RNReactNativeHapticFeedback.trigger_deprecated(type, options);
                 } else {
-                    NativeModules.RNReactNativeHapticFeedback.trigger(type);
+                    NativeModules.RNReactNativeHapticFeedback.trigger(type, mergedOptions);
                 }
             } else {
-                NativeModules.RNReactNativeHapticFeedback.trigger(type, options);
+                NativeModules.RNReactNativeHapticFeedback.trigger(type, mergedOptions);
             }
         } catch (err) {
             console.warn('RNReactNativeHapticFeedback is not available');

--- a/index.js
+++ b/index.js
@@ -2,22 +2,24 @@ import { NativeModules, Platform } from 'react-native';
 
 class RNReactNativeHapticFeedback {
     static trigger = (type = 'selection', options = {}) => {
-        // if options is a bool we're using a v1.6 api. This only effects iOS
+        // if options is a bool we're using a v1.6 api.
         if (typeof options === 'boolean' && Platform === 'ios') {
-            return trigger(type, options)
+            triggerHaptic(type, options)
+        } else if (typeof options === 'boolean') {
+            triggerHaptic(type, {})
+        } else {
+            const mergedOptions = {
+                enableVibrateFallback: false,
+                ignoreAndroidSystemSettings: false,
+                ...options
+            }
+    
+            triggerHaptic(type, mergedOptions)
         }
-
-        const mergedOptions = {
-            enableVibrateFallback: false,
-            ignoreAndroidSystemSettings: false,
-            ...options
-        }
-
-        trigger(type, mergedOptions)
     }
 }
 
-const trigger(type, options) {
+const triggerHaptic(type, options) {
     try {
         NativeModules.RNReactNativeHapticFeedback.trigger(type, options);
     } catch (err) {

--- a/index.js
+++ b/index.js
@@ -9,12 +9,8 @@ class RNReactNativeHapticFeedback {
         }
 
         try {
-            if (typeof options === 'boolean') {
-                if (Platform === 'ios') {
-                    NativeModules.RNReactNativeHapticFeedback.trigger_deprecated(type, options);
-                } else {
-                    NativeModules.RNReactNativeHapticFeedback.trigger(type, mergedOptions);
-                }
+            if (typeof options === 'boolean' && Platform === 'ios') {
+                NativeModules.RNReactNativeHapticFeedback.trigger(type, options);
             } else {
                 NativeModules.RNReactNativeHapticFeedback.trigger(type, mergedOptions);
             }

--- a/index.js
+++ b/index.js
@@ -2,21 +2,26 @@ import { NativeModules, Platform } from 'react-native';
 
 class RNReactNativeHapticFeedback {
     static trigger = (type = 'selection', options = {}) => {
+        // if options is a bool we're using a v1.6 api. This only effects iOS
+        if (typeof options === 'boolean' && Platform === 'ios') {
+            return trigger(type, options)
+        }
+
         const mergedOptions = {
             enableVibrateFallback: false,
             ignoreAndroidSystemSettings: false,
             ...options
         }
 
-        try {
-            if (typeof options === 'boolean' && Platform === 'ios') {
-                NativeModules.RNReactNativeHapticFeedback.trigger(type, options);
-            } else {
-                NativeModules.RNReactNativeHapticFeedback.trigger(type, mergedOptions);
-            }
-        } catch (err) {
-            console.warn('RNReactNativeHapticFeedback is not available');
-        }
+        trigger(type, mergedOptions)
+    }
+}
+
+const trigger(type, options) {
+    try {
+        NativeModules.RNReactNativeHapticFeedback.trigger(type, options);
+    } catch (err) {
+        console.warn('RNReactNativeHapticFeedback is not available');
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ import { NativeModules, Platform } from 'react-native';
 class RNReactNativeHapticFeedback {
     static trigger = (type = 'selection', options = {}) => {
         const mergedOptions = {
+            enableVibrateFallback: false,
             ignoreAndroidSystemSettings: false,
             ...options
         }

--- a/index.js
+++ b/index.js
@@ -1,12 +1,16 @@
-import {NativeModules, Platform} from 'react-native';
+import { NativeModules, Platform } from 'react-native';
 
 class RNReactNativeHapticFeedback {
-    static trigger = (type = 'selection', enableVibrateFallback = false) => {
+    static trigger = (type = 'selection', options = {}) => {
         try {
-            if (Platform.OS === 'ios') {
-                NativeModules.RNReactNativeHapticFeedback.trigger(type, enableVibrateFallback);
+            if (typeof options === 'boolean') {
+                if (Platform === 'ios') {
+                    NativeModules.RNReactNativeHapticFeedback.trigger_deprecated(type, options);
+                } else {
+                    NativeModules.RNReactNativeHapticFeedback.trigger(type);
+                }
             } else {
-                NativeModules.RNReactNativeHapticFeedback.trigger(type);
+                NativeModules.RNReactNativeHapticFeedback.trigger(type, options);
             }
         } catch (err) {
             console.warn('RNReactNativeHapticFeedback is not available');

--- a/ios/RNReactNativeHapticFeedback.m
+++ b/ios/RNReactNativeHapticFeedback.m
@@ -23,15 +23,15 @@ RCT_EXPORT_MODULE();
 
 RCT_EXPORT_METHOD(trigger_deprecated:(NSString *)type enableVibrateFallback:(BOOL)enableVibrateFallback)
 {
-    NSDictionary *options = [NSDictionary dictionary];
-    [options setObject: enableVibrateFallback  forKey: @"enableVibrateFallback"];
+    NSMutableDictionary *options = [NSMutableDictionary dictionary];
+    [options setObject:[NSNumber numberWithBool:enableVibrateFallback]  forKey: @"enableVibrateFallback"];
     
-    [self trigger type:type options:options]
+    [self trigger:type options:options];
 }
 
 RCT_EXPORT_METHOD(trigger:(NSString *)type options:(NSDictionary *)options)
 {
-    BOOL enableVibrateFallback = [options valueForKey:@"enableVibrateFallback"];
+    BOOL enableVibrateFallback = [[options objectForKey:@"enableVibrateFallback"]boolValue];
     
     if ([self supportsHaptic]){
         

--- a/ios/RNReactNativeHapticFeedback.m
+++ b/ios/RNReactNativeHapticFeedback.m
@@ -21,14 +21,6 @@
 
 RCT_EXPORT_MODULE();
 
-RCT_EXPORT_METHOD(trigger_deprecated:(NSString *)type enableVibrateFallback:(BOOL)enableVibrateFallback)
-{
-    NSMutableDictionary *options = [NSMutableDictionary dictionary];
-    [options setObject:[NSNumber numberWithBool:enableVibrateFallback]  forKey: @"enableVibrateFallback"];
-    
-    [self trigger:type options:options];
-}
-
 RCT_EXPORT_METHOD(trigger:(NSString *)type options:(NSDictionary *)options)
 {
     BOOL enableVibrateFallback = [[options objectForKey:@"enableVibrateFallback"]boolValue];

--- a/ios/RNReactNativeHapticFeedback.m
+++ b/ios/RNReactNativeHapticFeedback.m
@@ -21,8 +21,18 @@
 
 RCT_EXPORT_MODULE();
 
-RCT_EXPORT_METHOD(trigger:(NSString *)type enableVibrateFallback:(BOOL)enableVibrateFallback)
+RCT_EXPORT_METHOD(trigger_deprecated:(NSString *)type enableVibrateFallback:(BOOL)enableVibrateFallback)
 {
+    NSDictionary *options = [NSDictionary dictionary];
+    [options setObject: enableVibrateFallback  forKey: @"enableVibrateFallback"];
+    
+    [self trigger type:type options:options]
+}
+
+RCT_EXPORT_METHOD(trigger:(NSString *)type options:(NSDictionary *)options)
+{
+    BOOL enableVibrateFallback = [options valueForKey:@"enableVibrateFallback"];
+    
     if ([self supportsHaptic]){
         
         if ([type isEqual: @"impactLight"]) {


### PR DESCRIPTION
Haptic feedback triggers despite the user's system settings. (If they turn off haptic via the accessibility settings then haptic does disable).

The change checks the haptic system settings prior to triggering and will return if haptic is disabled.