### PR TITLE
Use ES6 syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ class RNReactNativeHapticFeedback {
     }
 }
 
-const triggerHaptic(type, options) {
+const triggerHaptic = (type, options) => {
     try {
         NativeModules.RNReactNativeHapticFeedback.trigger(type, options);
     } catch (err) {


### PR DESCRIPTION
The current version results in errors when loading with metro bundler because of the syntax.