### PR TITLE
com.facebook.react.bridge.NoSuchKeyException

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,22 +7,25 @@ const defaultOptions = {
 
 class RNReactNativeHapticFeedback {
     static trigger = (type = 'selection', options = {}) => {
-        // if options is a bool we're using a v1.6 api.
-        if (typeof options === 'boolean' && Platform === 'ios') {
-            triggerHaptic(type, options)
-        } else if (typeof options === 'boolean') {
-            triggerHaptic(type, defaultOptions)
-        } else {   
-            triggerHaptic(type, { ...defaultOptions, ...options })
+        const triggerOptions = createTriggerOptions(options)
+
+        try {
+            NativeModules.RNReactNativeHapticFeedback.trigger(type, triggerOptions);
+        } catch (err) {
+            console.warn('RNReactNativeHapticFeedback is not available');
         }
     }
 }
 
-const triggerHaptic = (type, options) => {
-    try {
-        NativeModules.RNReactNativeHapticFeedback.trigger(type, options);
-    } catch (err) {
-        console.warn('RNReactNativeHapticFeedback is not available');
+const createTriggerOptions = options => {
+    // if options is a boolean we're using an api <=1.6 and we should pass use it to set the enableVibrateFallback option
+    if (typeof options === 'boolean') {
+        return {
+            ...defaultOptions,
+            enableVibrateFallback: options
+        }
+    } else {
+        return { ...defaultOptions, ...options }
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -1,20 +1,19 @@
 import { NativeModules, Platform } from 'react-native';
 
+const defaultOptions = {
+    enableVibrateFallback: false,
+    ignoreAndroidSystemSettings: false,
+}
+
 class RNReactNativeHapticFeedback {
     static trigger = (type = 'selection', options = {}) => {
         // if options is a bool we're using a v1.6 api.
         if (typeof options === 'boolean' && Platform === 'ios') {
             triggerHaptic(type, options)
         } else if (typeof options === 'boolean') {
-            triggerHaptic(type, {})
-        } else {
-            const mergedOptions = {
-                enableVibrateFallback: false,
-                ignoreAndroidSystemSettings: false,
-                ...options
-            }
-    
-            triggerHaptic(type, mergedOptions)
+            triggerHaptic(type, defaultOptions)
+        } else {   
+            triggerHaptic(type, { ...defaultOptions, ...options })
         }
     }
 }


### PR DESCRIPTION
Android will throw a `com.facebook.react.bridge.NoSuchKeyException` when using the old trigger arguments after the latest update.

Looks as though I forgot to test this scenario properly with #28 