### PR TITLE
fix: add src folder to npm in order to make codegen work

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,2 @@
 /Playground
-/src
 .vscode


### PR DESCRIPTION
@mkuczera could you please restore `src` folder to npm package and release new version with it? This folder is needed in order for codegen to work correctly since it looks for this folder while parsing specs. Also, what is the reason for not including it anyways?