### PR TITLE
FIX: iOS build issues with new architecture 

### DIFF
--- a/RNReactNativeHapticFeedback.podspec
+++ b/RNReactNativeHapticFeedback.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.license      = "MIT"
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "m.kuczera@gmail.com" }
-  s.platform     = :ios, "9.0"
+  s.platform     = :ios, "12.4"
   s.source       = { :git => "https://github.com/mkuczera/react-native-haptic-feedback.git", :tag => "master" }
   s.source_files  = "ios/**/*.{h,m,mm}"
   s.requires_arc = true
@@ -37,4 +37,4 @@ Pod::Spec.new do |s|
   end
 end
 
-  
+


### PR DESCRIPTION
Fixing error `'value' is unavailable: introduced in iOS 12.0`
Issue related to 14.3 version of Xcode and new arch enabled  

Issue - https://github.com/mkuczera/react-native-haptic-feedback/issues/100