### PR TITLE
Fix Android Vibration enable condition

### DIFF
--- a/android/src/main/java/com/mkuczera/RNReactNativeHapticFeedbackModuleImpl.java
+++ b/android/src/main/java/com/mkuczera/RNReactNativeHapticFeedbackModuleImpl.java
@@ -37,7 +37,6 @@ public class RNReactNativeHapticFeedbackModuleImpl {
     public static void trigger(ReactApplicationContext reactContext, String type, ReadableMap options) {
       // Check system settings, if disabled and we're not explicitly ignoring then return immediatly
       boolean ignoreAndroidSystemSettings = options.getBoolean("ignoreAndroidSystemSettings");
-      int hapticEnabledAndroidSystemSettings = Settings.System.getInt(reactContext.getContentResolver(), Settings.System.HAPTIC_FEEDBACK_ENABLED, 0);
       boolean isVibrationEnabled = isVibrationEnabled(reactContext);
 
       if (ignoreAndroidSystemSettings == false && !isVibrationEnabled) return;


### PR DESCRIPTION
# Problem
There seems to be a problem with the `ignoreAndroidSystemSettings `option. Many people have no haptic response when the `ignoreAndroidSystemSettings `option is set to `false`, so they are using it with it set to `true`.  (https://github.com/mkuczera/react-native-haptic-feedback/issues/97)

The previously used `Settings.System.HAPTIC_FEEDBACK_ENABLED` option has been deprecated and no longer returns the enabled state of haptic. Because it simply returns a string called `haptic_feedback_enabled`, hapticEnabledAndroidSystemSettings always has to be `0`.
https://developer.android.com/reference/android/provider/Settings.System#HAPTIC_FEEDBACK_ENABLED

# Suggestion
So I propose a new vibration enable condition.

The first is when the device has a vibration function.

The second is when the user turns on the sound of the device or puts it in vibrate mode.

When the above two conditions are satisfied, it can be considered that the user has enabled haptic.

