### PR TITLE
Refactor: Align Package Name with Directory Structure for vibrateFactory

### DIFF
--- a/android/src/main/java/com/mkuczera/RNReactNativeHapticFeedbackModuleImpl.java
+++ b/android/src/main/java/com/mkuczera/RNReactNativeHapticFeedbackModuleImpl.java
@@ -3,8 +3,8 @@ package com.mkuczera;
 import android.os.Vibrator;
 import android.content.Context;
 import android.provider.Settings;
-import com.mkuczera.VibrateFactory;
-import com.mkuczera.Vibrate;
+import com.mkuczera.vibrateFactory.VibrateFactory;
+import com.mkuczera.vibrateFactory.Vibrate;
 
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;

--- a/android/src/main/java/com/mkuczera/RNReactNativeHapticFeedbackPackage.java
+++ b/android/src/main/java/com/mkuczera/RNReactNativeHapticFeedbackPackage.java
@@ -9,11 +9,7 @@ import com.facebook.react.module.model.ReactModuleInfoProvider;
 import com.facebook.react.TurboReactPackage;
 import com.facebook.react.uimanager.ViewManager;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 import java.util.HashMap;
-import java.util.Map;
 
 public class RNReactNativeHapticFeedbackPackage extends TurboReactPackage {
 

--- a/android/src/main/java/com/mkuczera/vibrateFactory/Vibrate.java
+++ b/android/src/main/java/com/mkuczera/vibrateFactory/Vibrate.java
@@ -1,5 +1,5 @@
 
-package com.mkuczera;
+package com.mkuczera.vibrateFactory;
 
 import android.os.Vibrator;
 

--- a/android/src/main/java/com/mkuczera/vibrateFactory/VibrateFactory.java
+++ b/android/src/main/java/com/mkuczera/vibrateFactory/VibrateFactory.java
@@ -1,15 +1,11 @@
-package com.mkuczera;
+package com.mkuczera.vibrateFactory;
 
 import java.util.Map;
 import java.util.HashMap;
-import java.util.Optional;
 
 import android.view.HapticFeedbackConstants;
 import android.os.VibrationEffect;
-import com.mkuczera.Vibrate;
-import com.mkuczera.VibrateWithDuration;
-import com.mkuczera.VibrateWithHapticConstant;
-import com.mkuczera.VibrateWithCreatePredefined;
+
 
 public class VibrateFactory {
     static Map<String, Vibrate> vibrateMap = new HashMap<>();

--- a/android/src/main/java/com/mkuczera/vibrateFactory/VibrateWithCreatePredefined.java
+++ b/android/src/main/java/com/mkuczera/vibrateFactory/VibrateWithCreatePredefined.java
@@ -1,4 +1,4 @@
-package com.mkuczera;
+package com.mkuczera.vibrateFactory;
 
 import android.os.Vibrator;
 import android.os.VibrationEffect;

--- a/android/src/main/java/com/mkuczera/vibrateFactory/VibrateWithDuration.java
+++ b/android/src/main/java/com/mkuczera/vibrateFactory/VibrateWithDuration.java
@@ -1,4 +1,4 @@
-package com.mkuczera;
+package com.mkuczera.vibrateFactory;
 
 import android.os.Vibrator;
 

--- a/android/src/main/java/com/mkuczera/vibrateFactory/VibrateWithHapticConstant.java
+++ b/android/src/main/java/com/mkuczera/vibrateFactory/VibrateWithHapticConstant.java
@@ -1,4 +1,4 @@
-package com.mkuczera;
+package com.mkuczera.vibrateFactory;
 
 import android.os.Vibrator;
 


### PR DESCRIPTION

### Problem

During an analysis of the `react-native-haptic-feedback` library using the Android Analyzer, a discrepancy was identified between the package declaration and the corresponding directory structure. The error flagged was:

```
Package name 'com.mkuczera' does not correspond to the file path 'com.mkuczera.VibrateFactory'
```

This mismatch not only confuses code readers but also potentially disrupts some tools from working correctly. Such an inconsistency, although not strictly mandated by the Java language, is important to address to ensure consistency and optimal functionality across various toolchains and IDEs.

### Solution

To address the highlighted inconsistency:

1. **Package Name Update**: I changed the package name from `com.mkuczera` to `com.mkuczera.vibrateFactory` to better align with the class's purpose and ensure it matches its directory.
   
2. **Directory Structure Adjustment**: The folder previously named `VibrateFactory` has been renamed to `vibrateFactory` (in camelCase) to reflect conventional Java naming standards and ensure alignment with the updated package name.
