### PR TITLE
feat: strict type on the trigger func argument

### DIFF
--- a/src/NativeHapticFeedback.ts
+++ b/src/NativeHapticFeedback.ts
@@ -1,10 +1,11 @@
 import type { TurboModule } from "react-native/Libraries/TurboModule/RCTExport";
 import { TurboModuleRegistry } from "react-native";
+import { HapticFeedbackTypes } from "./types";
 
 export interface Spec extends TurboModule {
   // your module methods go here, for example:
   trigger(
-    type: string,
+    type: keyof typeof HapticFeedbackTypes | HapticFeedbackTypes,
     options?: {
       enableVibrateFallback?: boolean;
       ignoreAndroidSystemSettings?: boolean;

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,11 +12,11 @@ const defaultOptions = {
 
 class RNReactNativeHapticFeedback {
   static trigger = (
-    type: string | HapticFeedbackTypes = HapticFeedbackTypes.selection,
+    type: keyof typeof HapticFeedbackTypes | HapticFeedbackTypes = HapticFeedbackTypes.selection,
     options: HapticOptions = {},
   ) => {
     const triggerOptions = createTriggerOptions(options);
-
+    
     try {
       const isTurboModuleEnabled = global.__turboModuleProxy != null;
       const hapticFeedback = isTurboModuleEnabled


### PR DESCRIPTION
Modified the method parameter type from a generic string to a stricter type definition.
This stricter type definition allows developers to intuitively understand available methods without referring to external documentation.
As a result, this enhances code readability, improves DX, and minimizes the chances of bugs due to incorrect method invocations.

as-is:
<img width="728" alt="image" src="https://github.com/mkuczera/react-native-haptic-feedback/assets/41789633/53d66e56-6f62-4b9b-b20a-f1466bedf281">



to-be:
![image](https://github.com/mkuczera/react-native-haptic-feedback/assets/41789633/3b720303-8c14-4fd4-8ba6-158042f34398)
