### PR TITLE
use right version in podspec

### DIFF
--- a/RNReactNativeHapticFeedback.podspec
+++ b/RNReactNativeHapticFeedback.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "m.kuczera@gmail.com" }
   s.platform     = :ios, "12.4"
-  s.source       = { :git => "https://github.com/mkuczera/react-native-haptic-feedback.git", :tag => "master" }
+  s.source       = { :git => "https://github.com/mkuczera/react-native-haptic-feedback.git", :tag => "v#{s.version.to_s}" }
   s.source_files  = "ios/**/*.{h,m,mm}"
   s.requires_arc = true
 


### PR DESCRIPTION
if you use an old tag, the latest native files get pulled. With this fix, the native files will match the installed version