### PR TITLE
fix: align with 0.75

### DIFF
--- a/RNReactNativeHapticFeedback.podspec
+++ b/RNReactNativeHapticFeedback.podspec
@@ -17,23 +17,12 @@ Pod::Spec.new do |s|
   s.source_files  = "ios/**/*.{h,m,mm}"
   s.requires_arc = true
 
-  s.dependency 'React-Core'
 
   # This guard prevent to install the dependencies when we run `pod install` in the old architecture.
-  if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then
-    folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
-
-    s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
-    s.pod_target_xcconfig    = {
-        "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
-        "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
-    }
-
-    s.dependency "React-Codegen"
-    s.dependency "RCT-Folly"
-    s.dependency "RCTRequired"
-    s.dependency "RCTTypeSafety"
-    s.dependency "ReactCommon/turbomodule/core"
+  if defined?(install_modules_dependencies()) != nil
+    install_modules_dependencies(s)
+  else
+    s.dependency 'React-Core'
   end
 end
 


### PR DESCRIPTION
Similar to e.g. https://github.com/software-mansion/react-native-svg/blob/979fb06b131c5280cc5be6325ce3bc264e29fe49/RNSVG.podspec#L24, we wan to utilize `install_modules_dependencies` method when it is already available (and it is from RN `0.71`). It also is required from RN `0.75` to even compile the project on new arch.