### PR TITLE
fix: use string instead of enum type to avoid codegen fails

### DIFF
--- a/src/NativeHapticFeedback.ts
+++ b/src/NativeHapticFeedback.ts
@@ -1,11 +1,10 @@
 import type { TurboModule } from "react-native/Libraries/TurboModule/RCTExport";
 import { TurboModuleRegistry } from "react-native";
-import { HapticFeedbackTypes } from "./types";
 
 export interface Spec extends TurboModule {
   // your module methods go here, for example:
   trigger(
-    type: keyof typeof HapticFeedbackTypes | HapticFeedbackTypes,
+    type: string,
     options?: {
       enableVibrateFallback?: boolean;
       ignoreAndroidSystemSettings?: boolean;


### PR DESCRIPTION
### Description

Codegen does not support Union Types and Enums. 

Closes #127 #128 

### Tests

You should be able to install the dependencies