### PR TITLE
fix: export types from index

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,5 +22,6 @@ const RNHapticFeedback = {
   }
 }
 
+export * from "./types";
 export const { trigger } = RNHapticFeedback;
 export default RNHapticFeedback;


### PR DESCRIPTION
Export types from `types.ts`

They were mistakenly removed during https://github.com/mkuczera/react-native-haptic-feedback/pull/135

https://github.com/mkuczera/react-native-haptic-feedback/pull/135#discussion_r1764975005

@mkuczera Would be great to get a patch version