### PR TITLE
fix: AudioToolbox linker, lambda build error, Android 8 vibration crash

### DIFF
--- a/RNReactNativeHapticFeedback.podspec
+++ b/RNReactNativeHapticFeedback.podspec
@@ -16,6 +16,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/mkuczera/react-native-haptic-feedback.git", :tag => "v#{s.version.to_s}" }
   s.source_files  = "ios/**/*.{h,m,mm}"
   s.requires_arc = true
+  s.frameworks   = 'AudioToolbox'
 
 
   # This guard prevent to install the dependencies when we run `pod install` in the old architecture.

--- a/android/src/main/java/com/mkuczera/RNReactNativeHapticFeedbackPackage.java
+++ b/android/src/main/java/com/mkuczera/RNReactNativeHapticFeedbackPackage.java
@@ -26,21 +26,24 @@ public class RNReactNativeHapticFeedbackPackage extends TurboReactPackage {
 
     @Override
     public ReactModuleInfoProvider getReactModuleInfoProvider() {
-        return () -> {
-            final Map<String, ReactModuleInfo> moduleInfos = new HashMap<>();
-            boolean isTurboModule = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED;
-            moduleInfos.put(
-                    RNReactNativeHapticFeedbackModuleImpl.NAME,
-                    new ReactModuleInfo(
-                            RNReactNativeHapticFeedbackModuleImpl.NAME,
-                            RNReactNativeHapticFeedbackModuleImpl.NAME,
-                            false, // canOverrideExistingModule
-                            false, // needsEagerInit
-                            true, // hasConstants
-                            false, // isCxxModule
-                            isTurboModule // isTurboModule
-            ));
-            return moduleInfos;
+        return new ReactModuleInfoProvider() {
+            @Override
+            public Map<String, ReactModuleInfo> getReactModuleInfos() {
+                final Map<String, ReactModuleInfo> moduleInfos = new HashMap<>();
+                boolean isTurboModule = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED;
+                moduleInfos.put(
+                        RNReactNativeHapticFeedbackModuleImpl.NAME,
+                        new ReactModuleInfo(
+                                RNReactNativeHapticFeedbackModuleImpl.NAME,
+                                RNReactNativeHapticFeedbackModuleImpl.NAME,
+                                false, // canOverrideExistingModule
+                                false, // needsEagerInit
+                                true, // hasConstants
+                                false, // isCxxModule
+                                isTurboModule // isTurboModule
+                ));
+                return moduleInfos;
+            }
         };
     }
 }

--- a/android/src/main/java/com/mkuczera/vibrateFactory/VibrateWithDuration.java
+++ b/android/src/main/java/com/mkuczera/vibrateFactory/VibrateWithDuration.java
@@ -1,6 +1,8 @@
 package com.mkuczera.vibrateFactory;
 
+import android.os.Build;
 import android.os.Vibrator;
+import android.os.VibrationEffect;
 
 public class VibrateWithDuration implements Vibrate {
     long durations[] = {};
@@ -13,7 +15,11 @@ public class VibrateWithDuration implements Vibrate {
     public void apply(Vibrator v) {
         try {
             if (v.hasVibrator()) {
-                v.vibrate(this.durations, -1);
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    v.vibrate(VibrationEffect.createWaveform(this.durations, -1));
+                } else {
+                    v.vibrate(this.durations, -1);
+                }
             }
         } catch (Exception e) {}
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-haptic-feedback",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "description": "Basic haptic feedback for iOS and android",
   "license": "MIT",
   "source": "src/index.ts",


### PR DESCRIPTION
## Summary

Three targeted hotfixes for the most-reported crashes in v2.3.3.

- **podspec** — declare `AudioToolbox` as an explicit framework; resolves the `_AudioServicesPlaySystemSound` linker error reported on some toolchains (#142, #118)
- **RNReactNativeHapticFeedbackPackage** — expand the `ReactModuleInfoProvider` lambda to an anonymous class; fixes build failures on Java toolchains that reject lambdas in `TurboReactPackage` (#115)
- **VibrateWithDuration** — guard `vibrator.vibrate(timings[], -1)` behind `Build.VERSION_CODES.O` and use `VibrationEffect.createWaveform` on API 26+; prevents the crash on Android 8 (#88)

## Releases as v2.3.4

No API changes. All existing behaviour is preserved.

## Test plan

- [ ] `yarn test` — all 3 existing tests pass
- [ ] iOS build does not produce `_AudioServicesPlaySystemSound` linker error
- [ ] Android build compiles cleanly on Java 11+ toolchains
- [ ] Vibration works on Android 8 (API 26) without crashing